### PR TITLE
Configure hatch editable target path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ tb = "trading_bot.cli:app"
 [tool.hatch.build.targets.wheel]
 packages = ["trading_bot"]
 
+[tool.hatch.build.targets.editable]
+path = "."
+
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- configure the Hatch editable build target to place the repository root on sys.path during editable installs

## Testing
- pip install -e '.[dev]'
- python -c "import trading_bot"
- tb fetch --help

------
https://chatgpt.com/codex/tasks/task_e_68d72614f9c0832ebae8385f3442a816