### PR TITLE
Configure Hatch dev mode directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ dev = [
 [project.scripts]
 tb = "trading_bot.cli:app"
 
+[tool.hatch.build]
+dev-mode-dirs = ["."]
+
 [tool.hatch.build.targets.wheel]
 packages = ["trading_bot"]
-
-[tool.hatch.build.targets.editable]
-path = "."
 
 [tool.pytest.ini_options]
 addopts = "-ra"


### PR DESCRIPTION
## Summary
- add a Hatch build configuration that includes the repository root for dev-mode installs
- remove the dedicated editable target section now that dev-mode directories are configured globally

## Testing
- `pip install -e '.[dev]'`
- `tb fetch --help`


------
https://chatgpt.com/codex/tasks/task_e_68d8498bf008832ea22b4d4717a3e8ed