### PR TITLE
Improve CLI handling when POLYGON_API_KEY is missing

### DIFF
--- a/trading_bot/live/streamer.py
+++ b/trading_bot/live/streamer.py
@@ -20,13 +20,22 @@ class AggregateStreamer:
     def __init__(self, ticker: str, api_key: str | None = None) -> None:
         self.ticker = ticker
         self.api_key = api_key or os.environ.get("POLYGON_API_KEY")
-        if not self.api_key:
-            raise RuntimeError("POLYGON_API_KEY environment variable is required")
-        self._client = WebSocketClient(
-            api_key=self.api_key, subscriptions=[f"A.{ticker}"], feed="delayed"
-        )
+        self._client: WebSocketClient | None = None
         self._queue: asyncio.Queue[pd.Series] = asyncio.Queue()
-        self._client.on_message = self._on_message
+
+    # ------------------------------------------------------------------
+    def _ensure_client(self) -> WebSocketClient:
+        if self._client is None:
+            if not self.api_key:
+                raise RuntimeError(
+                    "POLYGON_API_KEY environment variable is required to stream data from Polygon. "
+                    "Export the key before running `tb live`."
+                )
+            self._client = WebSocketClient(
+                api_key=self.api_key, subscriptions=[f"A.{self.ticker}"], feed="delayed"
+            )
+            self._client.on_message = self._on_message
+        return self._client
 
     def _on_message(self, message: WebSocketMessage) -> None:
         for event in message.events:
@@ -50,14 +59,15 @@ class AggregateStreamer:
             self._queue.put_nowait(bar)
 
     async def stream(self) -> AsyncIterator[pd.Series]:
+        client = self._ensure_client()
         log.info("streamer.start", ticker=self.ticker)
-        connect_task = asyncio.create_task(self._client.connect_async())
+        connect_task = asyncio.create_task(client.connect_async())
         try:
             while True:
                 bar = await self._queue.get()
                 yield bar
         finally:
-            self._client.close()
+            client.close()
             await connect_task
             log.info("streamer.stop", ticker=self.ticker)
 


### PR DESCRIPTION
## Summary
- defer Polygon API key validation so cached data can be read without credentials and add clearer errors when an online call is required
- improve CLI commands by surfacing actionable guidance for missing Polygon credentials and validating report files before plotting
- add a regression test ensuring cached data loads without an API key

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da10f3aad8832e91399a7b65b35f79