### PR TITLE
Fix editable install path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ dev = [
 tb = "trading_bot.cli:app"
 
 [tool.hatch.build]
-dev-mode-dirs = ["."]
+# Ensure editable installs expose the package directory on sys.path instead of
+# the repository root. This avoids situations where the generated `.pth` file
+# points at a stale checkout location, which manifested as `ModuleNotFoundError`
+# for `trading_bot` when running the CLI after an editable install.
+dev-mode-dirs = ["trading_bot"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["trading_bot"]


### PR DESCRIPTION
## Summary
- point hatch's editable install path at the package directory so the `tb` CLI can be imported immediately after an editable install
- document the rationale in pyproject.toml to prevent regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da1358d74c832e9ed825dcb5af7c52